### PR TITLE
[HOTFIX] Unique parameter to avoid hash collision wiht higher number of GPUs

### DIFF
--- a/dask_cuml/linear_model/linear_regression.py
+++ b/dask_cuml/linear_model/linear_regression.py
@@ -112,6 +112,7 @@ class LinearRegression(object):
             coefs.append(client.submit(dev_array_on_worker,
                                        up_limit - i*part_size,
                                        dtype=dtype,
+                                       unique=np.random.randint(0, 1e6),
                                        workers=[loc_dict[i]]))
             yield wait(coefs)
             del(loc_cudf)


### PR DESCRIPTION
Without this fix, the coefficient arrays of one gpu can overwrite others due to task key collision. 