### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/conda/recipes/dask-cuml/meta.yaml
+++ b/conda/recipes/dask-cuml/meta.yaml
@@ -47,8 +47,8 @@ test:
     - cudf
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask-cudf
-    - dask-cuda
+    - dask_cudf
+    - dask_cuda
 
 about:
   home: http://rapids.ai

--- a/conda/recipes/dask-cuml/meta.yaml
+++ b/conda/recipes/dask-cuml/meta.yaml
@@ -17,7 +17,7 @@
 # Usage:
 #   conda build -c defaults -c conda-forge .
 package:
-  name: dask_cuml
+  name: dask-cuml
   version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') }}
 
 source:
@@ -32,23 +32,23 @@ requirements:
     - cudf
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask_cudf
-    - dask_cuda
+    - dask-cudf
+    - dask-cuda
   run:
     - python
     - cudf
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask_cudf
-    - dask_cuda
+    - dask-cudf
+    - dask-cuda
 test:
   imports:
     - python
     - cudf
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask_cudf
-    - dask_cuda
+    - dask-cudf
+    - dask-cuda
 
 about:
   home: http://rapids.ai

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name="dask_cuml",
         "Programming Language :: Python :: 3.7"
       ],
       author="NVIDIA Corporation",
-      url="https://github.com/rapidsai/dask_cuml",
+      url="https://github.com/rapidsai/dask-cuml",
       install_requires=install_requires,
       license="Apache Software License 2.0",
       cmdclass=versioneer.get_cmdclass(),

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ packages = ["dask_cuml",
             "dask_cuml.neighbors",
             "dask_cuml.linear_model"]
 
-setup(name="dask_cuml",
+setup(name="dask-cuml",
       description="Distributed ML algorithms on GPUs using Dask",
       version=versioneer.get_version(),
       classifiers=[


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.