### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/cpu/dask-cuml/build_dask_cuml.sh
+++ b/ci/cpu/dask-cuml/build_dask_cuml.sh
@@ -4,4 +4,4 @@ set -e
 
 echo "Building dask-cuml"
 
-conda build conda/recipes/dask-cuml -c conda-forge -c numba -c rapidsai/label/cuda${CUDA} -c rapidsai-nightly/label/cuda${CUDA} -c nvidia/label/cuda${CUDA} -c pytorch -c defaults --python=${PYTHON}
+conda build conda/recipes/dask-cuml -c conda-forge -c numba -c rapidsai -c rapidsai-nightly -c nvidia -c pytorch --python=${PYTHON}

--- a/ci/cpu/dask-cuml/upload-anaconda.sh
+++ b/ci/cpu/dask-cuml/upload-anaconda.sh
@@ -1,38 +1,15 @@
 #!/bin/bash
 #
 # Adopted from https://github.com/tmcdonell/travis-scripts/blob/dfaac280ac2082cd6bcaba3217428347899f2975/update-accelerate-buildbot.sh
+export UPLOADFILE=`conda build conda/recipes/dask-cudf -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c defaults -c conda-forge --python=$PYTHON --output`
 
 set -e
 
-CUDA_REL=${CUDA:0:3}
-if [ "${CUDA:0:2}" == '10' ]; then
-  # CUDA 10 release
-  CUDA_REL=${CUDA:0:4}
-fi
-
-if [ "$BUILD_ABI" == "1" ]; then
-  export UPLOADFILE=`conda build conda/recipes/dask-cuml -c conda-forge -c numba -c rapidsai/label/cuda${CUDA_REL} -c nvidia/label/cuda${CUDA_REL} -c pytorch -c defaults --python=${PYTHON} --output`
-else
-  export UPLOADFILE=`conda build conda/recipes/dask-cuml -c conda-forge/label/cf201901 -c numba -c rapidsai/label/cf201901-cuda${CUDA_REL} -c nvidia/label/cf201901-cuda${CUDA_REL} -c pytorch -c defaults --python=${PYTHON} --output`
-fi
-
 SOURCE_BRANCH=master
 
-if [ "$LABEL_MAIN" == "1" -a "$BUILD_ABI" == "1" ]; then
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
-elif [ "$LABEL_MAIN" == "0" -a "$BUILD_ABI" == "1" ]; then
-  LABEL_OPTION="--label dev --label cuda${CUDA_REL}"
-elif [ "$LABEL_MAIN" == "1" -a "$BUILD_ABI" == "0" ]; then
-  LABEL_OPTION="--label cf201901 --label cf201901-cuda${CUDA_REL}"
-elif [ "$LABEL_MAIN" == "0" -a "$BUILD_ABI" == "0" ]; then
-  LABEL_OPTION="--label cf201901-dev --label cf201901-cuda${CUDA_REL}"
-else
-  echo "Unknown label configuration LABEL_MAIN='$LABEL_MAIN' BUILD_ABI='$BUILD_ABI'"
-  exit 1
-fi
-echo "LABEL_OPTION=${LABEL_OPTION}"
-
 test -e ${UPLOADFILE}
+
+LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
 
 # Restrict uploads to master branch
 if [ ${GIT_BRANCH} != ${SOURCE_BRANCH} ]; then
@@ -45,6 +22,8 @@ if [ -z "$MY_UPLOAD_KEY" ]; then
   return 0
 fi
 
+echo "LABEL_OPTION=${LABEL_OPTION}"
+
 echo "Upload"
 echo ${UPLOADFILE}
-anaconda -t ${MY_UPLOAD_KEY} upload -u rapidsai ${LABEL_OPTION} --force ${UPLOADFILE}
+anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --force ${UPLOADFILE}

--- a/ci/cpu/dask-cuml/upload-anaconda.sh
+++ b/ci/cpu/dask-cuml/upload-anaconda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Adopted from https://github.com/tmcdonell/travis-scripts/blob/dfaac280ac2082cd6bcaba3217428347899f2975/update-accelerate-buildbot.sh
-export UPLOADFILE=`conda build conda/recipes/dask-cudf -c nvidia -c rapidsai -c rapidsai-nightly -c numba -c defaults -c conda-forge --python=$PYTHON --output`
+export UPLOADFILE=`conda build conda/recipes/dask-cuml -c conda-forge -c numba -c rapidsai -c rapidsai-nightly -c nvidia -c pytorch --python=${PYTHON} --output`
 
 set -e
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.