### PR TITLE
Specified 0.7 versions of RAPIDS packages

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -32,7 +32,18 @@ logger "Activate conda env..."
 source activate gdf
 
 logger "conda install -c nvidia/label/cuda$CUDA_REL -c rapidsai/label/cuda$CUDA_REL -c conda-forge -c defaults -c rapidsai-nightly/label/cuda$CUDA_REL cuml dask distributed cudf dask-cudf dask-cuda"
-conda install -c nvidia/label/cuda$CUDA_REL -c rapidsai/label/cuda$CUDA_REL -c conda-forge -c defaults -c rapidsai-nightly/label/cuda$CUDA_REL cuml dask distributed cudf dask-cudf dask-cuda
+conda install \
+      -c nvidia/label/cuda$CUDA_REL \
+      -c rapidsai/label/cuda$CUDA_REL \
+      -c conda-forge \
+      -c defaults \
+      -c rapidsai-nightly/label/cuda$CUDA_REL \
+      cuml=0.7* \
+      dask \
+      distributed \
+      cudf=0.7* \
+      dask-cudf=0.7* \
+      dask-cuda=0.7*
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -31,7 +31,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate gdf
 
-logger "conda install -c nvidia/label/cuda$CUDA_REL -c rapidsai/label/cuda$CUDA_REL -c conda-forge -c defaults -c rapidsai-nightly/label/cuda$CUDA_REL cuml dask distributed cudf dask-cudf dask-cuda"
+logger "conda install -c nvidia/label/cuda$CUDA_REL -c rapidsai/label/cuda$CUDA_REL -c conda-forge -c defaults -c rapidsai-nightly/label/cuda$CUDA_REL cuml=0.7* dask distributed cudf=0.7* dask-cudf=0.7* dask-cuda=0.7*"
 conda install \
       -c nvidia/label/cuda$CUDA_REL \
       -c rapidsai/label/cuda$CUDA_REL \

--- a/conda/recipes/dask-cuml/meta.yaml
+++ b/conda/recipes/dask-cuml/meta.yaml
@@ -29,18 +29,18 @@ build:
 requirements:
   build:
     - python
-    - cudf
+    - cudf 0.7*
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask-cudf
-    - dask-cuda
+    - dask-cudf 0.7*
+    - dask-cuda 0.7*
   run:
     - python
-    - cudf
+    - cudf 0.7*
     - dask >=0.19.0
     - distributed >=1.23.0
-    - dask-cudf
-    - dask-cuda
+    - dask-cudf 0.7*
+    - dask-cuda 0.7*
 test:
   imports:
     - cudf


### PR DESCRIPTION
The lack of version spec caused this conda package to install 0.8 dependencies, now that they are available.