### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# dask-cuML 0.8.0
+# dask-cuML 0.8.0 (27 June 2019)
 
 Note: dask-cuML will be merged into the cuML repository in future releases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# dask-cuML 0.8.0
+
+Note: dask-cuML will be merged into the cuML repository in future releases.
+
+## New Features
+
+## Improvements
+
+## Bug Fixes
+
+- PR #46 - Fix order of function arguments to support new cuML nearest neighbors
+- PR #45 - Fix conda dependencies
+


### PR DESCRIPTION
The ops team would like us to add a changelog, even if it's relatively minimal. This is for 0.8 so a bit of a hurry.